### PR TITLE
Remove pry debugger

### DIFF
--- a/lib/bauditor/cli.rb
+++ b/lib/bauditor/cli.rb
@@ -1,6 +1,5 @@
 require 'thor'
 require 'fileutils'
-require 'pry'
 
 module Bauditor
   class CLI < ::Thor


### PR DESCRIPTION
This removes `pry` require as it's not defined in gemspec and it's not needed to run bauditor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leklund/bauditor/1)
<!-- Reviewable:end -->
